### PR TITLE
Update node-providers-add-1rpc-OP-support

### DIFF
--- a/community/node-providers.md
+++ b/community/node-providers.md
@@ -14,4 +14,8 @@ Feel free to try [fast and reliable nodes](https://drpc.org/public-endpoints/opt
 
 ## [1RPC](https://www.1rpc.io/)
 
-1RPC supports OP Mainnet and is the first and only on-chain attested privacy preserving RPC that eradicate metadata exposure and leakage when interacting with blockchains.
+[1RPC](https://1rpc.io/) is the first and only on-chain attested privacy preserving RPC that eradicate metadata exposure and leakage when interacting with blockchains. 1RPC offers free and [subscription plans](https://www.1rpc.io/#pricing) with dedicated unique API keys and higher rate limits. Access 1RPC OP Mainnet endpoints [here](https://docs.1rpc.io/overview/supported-networks#optimism).
+
+### Supported Networks
+
+- OP Mainnet

--- a/community/node-providers.md
+++ b/community/node-providers.md
@@ -1,3 +1,7 @@
 # Node Providers
 
 Checkout the node and API providers that our community is using or has built! Please open a pull request if you'd like something to be added to this list.
+
+## [1RPC](https://www.1rpc.io/)
+
+1RPC supports OP Mainnet and is the first and only on-chain attested privacy preserving RPC that eradicate metadata exposure and leakage when interacting with blockchains. 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adding 1RPC to Optimism Dev Docs. 1RPC has relayed over 2 billion requests on Optimism.

https://docs.1rpc.io/overview/supported-networks

**Tests**

We have tested in local environment and RPC support for OP Mainnet already live.

**Additional context**

Protecting users' privacy during blockchain interactions, with our free RPC relay.

**Metadata**

- Fixes #[Link to Issue]
