### PR TITLE
adds envio to blockchain indexers

### DIFF
--- a/community/tools/blockchain-indexers.md
+++ b/community/tools/blockchain-indexers.md
@@ -2,6 +2,17 @@
 
 Blockchain data is not easily queryable by default. Indexing tools help with extracting data from blockchain node, transforming it in a way that is understandable by human or computers, and loading it to a database or any other destination for querying.
 
+## Envio
+
+[Envio](https://envio.dev) is a full-featured data indexing solution that provides application developers with a seamless and efficient way to query real-time and historical blockchain data for any EVM. 
+
+Envio [HyperSync](https://docs.envio.dev/docs/hypersync) is an indexed layer of the Optimism blockchain for the hyper-speed syncing of historical data (100x faster than JSON-RPC). What would usually take hours to sync ~100,000 events can now be done in the order of less than a minute. 
+
+Designed to optimize the user experience, Envio offers automatic code generation, flexible language support, multi-chain data aggregation, and a reliable cost-effective [hosted service](https://docs.envio.dev/docs/hosted-service).
+
+To get started, visit the [documentation](https://docs.envio.dev/docs/overview) or follow the [quickstart](https://docs.envio.dev/docs/quickstart) guide.
+
+
 ## Flair
 
 [Flair](https://flair.dev) is a real-time and historical custom data indexing for any evm chain.

--- a/community/tools/blockchain-indexers.md
+++ b/community/tools/blockchain-indexers.md
@@ -2,6 +2,14 @@
 
 Blockchain data is not easily queryable by default. Indexing tools help with extracting data from blockchain node, transforming it in a way that is understandable by human or computers, and loading it to a database or any other destination for querying.
 
+## Flair
+
+[Flair](https://flair.dev) is a real-time and historical custom data indexing for any evm chain.
+
+It offers reusable **indexing primitives** (such as fault-tolerant RPC ingestors, custom processors and aggregations, re-org aware database integrations) to make it easy to receive, transform, store and access your on-chain data.
+
+To get started, visit the [documentation](https://docs.flair.dev) or clone the [starter boilerplate](https://github.com/flair-sdk/starter-boilerplate) template and follow the instructions.
+
 ## Envio
 
 [Envio](https://envio.dev) is a full-featured data indexing solution that provides application developers with a seamless and efficient way to query real-time and historical blockchain data for any EVM. 
@@ -11,12 +19,3 @@ Envio [HyperSync](https://docs.envio.dev/docs/hypersync) is an indexed layer of 
 Designed to optimize the user experience, Envio offers automatic code generation, flexible language support, multi-chain data aggregation, and a reliable cost-effective [hosted service](https://docs.envio.dev/docs/hosted-service).
 
 To get started, visit the [documentation](https://docs.envio.dev/docs/overview) or follow the [quickstart](https://docs.envio.dev/docs/quickstart) guide.
-
-
-## Flair
-
-[Flair](https://flair.dev) is a real-time and historical custom data indexing for any evm chain.
-
-It offers reusable **indexing primitives** (such as fault-tolerant RPC ingestors, custom processors and aggregations, re-org aware database integrations) to make it easy to receive, transform, store and access your on-chain data.
-
-To get started, visit the [documentation](https://docs.flair.dev) or clone the [starter boilerplate](https://github.com/flair-sdk/starter-boilerplate) template and follow the instructions.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add Envio as a supported blockchain data indexing solution for OP

**Tests**

- Preview markdown file before creating PR
- Manually tested links are working

**Additional context**

- Envio is a supported indexer for Optimism and listed on ecosystem apps: https://www.optimism.io/apps/tools

**Metadata**

- None
