### PR TITLE
ci: migrate CircleCI jobs to Gen2 resource classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   linux:
     machine:
-      image: ubuntu-2204:2024.08.1
+      image: ubuntu-2204:current
     resource_class: medium.gen2
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   linux:
     machine:
       image: ubuntu-2204:2024.08.1
-    resource_class: medium
+    resource_class: medium.gen2
 
 jobs:
   developer-discussion-metrics:


### PR DESCRIPTION
## Summary

Same-size Gen1 → Gen2 swap for the `linux` executor in this repo (1 line change in `executors:`, affects 3 jobs). Part of W4 of the CircleCI cost-reduction initiative — ethereum-optimism/core-team#2564.

## Change

| File | Edit | Affects |
|---|---|---|
| `.circleci/config.yml` | `resource_class: medium` → `medium.gen2` on the `linux` executor | 3 jobs (`developer-discussion-metrics`, `developer-issue-metrics`, `developer-pr-metrics`) |
| `.circleci/config.yml` | `image: ubuntu-2204:2024.08.1` → `image: ubuntu-2204:current` | same executor |

## Why both changes in one PR

The original pin `ubuntu-2204:2024.08.1` predates Gen2 support and CircleCI rejects it when paired with `medium.gen2` (*"Job was rejected because resource class medium.gen2, image ubuntu-2204:2024.08.1 is not a valid resource class"*). Bumping to `:current` matches the pin used by ethereum-optimism/optimism#20927, where the same combo is running green.

## Potential downstream effect

Moving the host image from August 2024 to `:current` shifts the underlying OS and language toolchain versions. If any of the 3 metric-collection jobs pin specific apt packages, Python versions, or generated lockfiles, those may need a refresh. Worth a maintainer review before merging — if jobs pass green, no action needed; if they fail on an environment delta, the fix belongs in the job's setup steps or a follow-up commit.

## Precedent

- ethereum-optimism/optimism#20917 (41 jobs, all 99 checks green)
- ethereum-optimism/optimism#20927 (22 jobs including the same `ubuntu-2204:current` machine pin)

## Refs

- ethereum-optimism/core-team#2564
